### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+dist: trusty
+env:
+  - DEBIAN_FRONTEND=noninteractive
+sudo: false
 language: python
 python:
   - "3.4"
@@ -9,9 +13,6 @@ addons:
   apt:
     packages:
       - libav-tools
-      - python3-demjson
+      - python3-simplejson
       - youtube-dl
-# command to install dependencies
-# install: "pip install -r requirements.txt"
-# command to run tests
-script: py.test
+script: py.test-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
   apt:
     packages:
       - libav-tools
+      - python3-pytest
       - python3-simplejson
       - youtube-dl
 script: py.test-3


### PR DESCRIPTION
Travis' default build env is `ubuntu-precise`, which has poor support for python3. Switched to their `trusty` container env, and updated required packages to `python3-simplejson` and `python3-pytest`.